### PR TITLE
Dynamically set up MSVC environment

### DIFF
--- a/2、run_gradio.ps1
+++ b/2、run_gradio.ps1
@@ -1,4 +1,30 @@
-# run script by @bdsqlsz
+# run script by @bdsqlsz, A-N-I-K
+
+# Find where the latest MSVC is installed dynamically
+$vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if (Test-Path $vswherePath) {
+    $vcvarsPath = & $vswherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    if ($vcvarsPath) {
+        $vcvarsPath = Join-Path $vcvarsPath "VC\Auxiliary\Build\vcvars64.bat"
+    }
+} else {
+    Write-Host "ERROR: vswhere.exe not found! Please ensure Visual Studio is installed."
+    exit 1
+}
+
+# Ensure the path is valid
+if (Test-Path $vcvarsPath) {
+    Write-Host "Setting up MSVC environment..."
+    cmd.exe /c "`"$vcvarsPath`" && set" | foreach {
+        if ($_ -match "^(.*?)=(.*)$") {
+            Set-Content -Path "env:\$($matches[1])" -Value "$($matches[2])"
+        }
+    }
+} else {
+    Write-Host "ERROR: vcvars64.bat could not be found! Please make sure MSVC is installed properly."
+    exit 1
+}
 
 # Activate python venv
 Set-Location $PSScriptRoot


### PR DESCRIPTION
This fixes the missing `vcruntime.h` issue that can occur when MSVC is not properly configured in the Include and Library paths.